### PR TITLE
Add RDKit database cartridge

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   db:
-    image: postgres
+    image: informaticsmatters/rdkit_cartridge 
   web:
     build: .
     command: python manage.py runserver 0.0.0.0:8000


### PR DESCRIPTION
現在のpostgreSQLのDocker imageをRDKit Database Cartridgeをすでに実装している  
PostgreSQLのDocker imageに変更する。
[https://hub.docker.com/r/informaticsmatters/rdkit_cartridge/](https://hub.docker.com/r/informaticsmatters/rdkit_cartridge/)