### PR TITLE
Use pip for install django_rdkit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,5 @@ RUN mkdir /code
 WORKDIR /code
 ADD requirements.txt /code/
 RUN pip install -r requirements.txt
-RUN git clone https://github.com/rdkit/django-rdkit.git && python ./django-rdkit/setup.py install
+RUN pip install git+https://github.com/rdkit/django-rdkit.git
 ADD . /code/
-


### PR DESCRIPTION
dockerコンテナ内で `import django_rdkit` 出来ない問題を解決しました